### PR TITLE
Avoid sending data from NPC vehicle.

### DIFF
--- a/carla_agent/simulation/world.py
+++ b/carla_agent/simulation/world.py
@@ -78,7 +78,7 @@ class World(object):
         cam_pos_index = self.camera_manager.transform_index if self.camera_manager is not None else 0
         # Get a random blueprint.
         blueprint = random.choice(get_actor_blueprints(self.world, self._actor_filter, self._actor_generation))
-        blueprint.set_attribute('role_name', self.actor_role_name)
+        blueprint.set_attribute('role_name', "autoware_"+self.actor_role_name)
         if blueprint.has_attribute('color'):
             color = random.choice(blueprint.get_attribute('color').recommended_values)
             blueprint.set_attribute('color', color)

--- a/src/bridge/sensor_bridge.rs
+++ b/src/bridge/sensor_bridge.rs
@@ -67,7 +67,7 @@ impl SensorBridge {
         let sensor_id = actor.id();
         let sensor_type_id = actor.type_id();
 
-        let vehicle_name = actor
+        let mut vehicle_name = actor
             .parent()
             .ok_or(Error::OwnerlessSensor { sensor_id })?
             .attributes()
@@ -81,6 +81,15 @@ impl SensorBridge {
             .find(|attr| attr.id() == "role_name")
             .map(|attr| attr.value_string())
             .unwrap_or_else(|| generate_sensor_name(&actor));
+
+        // Remove "autoware_" in role name
+        if !vehicle_name.starts_with("autoware_") {
+            return Err(Error::Npc {
+                npc_role_name: vehicle_name,
+            });
+        } else {
+            vehicle_name = vehicle_name.replace("autoware_", "");
+        }
 
         info!("Detected a sensor '{sensor_name}' on '{vehicle_name}'");
         let sensor_type: SensorType = sensor_type_id.parse().unwrap();

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,4 +13,7 @@ pub enum Error {
 
     #[error("The sensor with ID {sensor_id} is ownerless.")]
     OwnerlessSensor { sensor_id: u32 },
+
+    #[error("The vehicle is NPC")]
+    Npc { npc_role_name: String },
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use carla::{client::Client, prelude::*, rpc::ActorId};
 use clap::Parser;
 use clock::SimulatorClock;
 use error::Error;
-use log::{error, info};
+use log::{debug, info};
 use std::{
     collections::{HashMap, HashSet},
     sync::Arc,
@@ -96,9 +96,13 @@ fn main() -> Result<(), Error> {
                 let bridge = match bridge::actor_bridge::create_bridge(z_session.clone(), actor) {
                     Ok(bridge) => bridge,
                     Err(Error::OwnerlessSensor { sensor_id }) => {
-                        error!(
+                        debug!(
                             "Ignore the sensor with ID {sensor_id} is not attached to any vehicle."
                         );
+                        continue;
+                    }
+                    Err(Error::Npc { npc_role_name }) => {
+                        debug!("Ignore NPC vehicle {npc_role_name}.");
                         continue;
                     }
                     Err(err) => return Err(err),


### PR DESCRIPTION
I added "autoware_" in the vehicles we want to control with Autoware. Other vehicles are seen as NPC vehicles and don't create bridge for them.