### PR TITLE
Add rmw_zenoh mode

### DIFF
--- a/src/autoware.rs
+++ b/src/autoware.rs
@@ -8,9 +8,9 @@ use crate::{bridge::sensor_bridge::SensorType, Mode};
 #[inline]
 fn topic_fmt(prefix: &str, mode: &Mode, base: &str) -> String {
     if *mode == Mode::RmwZenoh {
-        format!("{prefix}*/{base}/*/*", prefix = prefix, base = base)
+        format!("{prefix}*/{base}/*/*")
     } else {
-        format!("{prefix}{base}", prefix = prefix, base = base)
+        format!("{prefix}{base}")
     }
 }
 
@@ -45,8 +45,8 @@ pub struct Autoware {
 impl Autoware {
     pub fn new(vehicle_name: String, mode: Mode) -> Autoware {
         let prefix = match mode {
-            Mode::ROS2 | Mode::RmwZenoh => format!("{}/", vehicle_name),
-            Mode::DDS => format!("{}/rt/", vehicle_name),
+            Mode::ROS2 | Mode::RmwZenoh => format!("{vehicle_name}/"),
+            Mode::DDS => format!("{vehicle_name}/rt/"),
         };
         let topic = |base: &str| topic_fmt(&prefix, &mode, base);
         Autoware {
@@ -83,12 +83,12 @@ impl Autoware {
                 let raw_key = topic_fmt(
                     &self.prefix,
                     &self.mode,
-                    &format!("sensing/camera/{}/image_raw", sensor_name),
+                    &format!("sensing/camera/{sensor_name}/image_raw"),
                 );
                 let info_key = topic_fmt(
                     &self.prefix,
                     &self.mode,
-                    &format!("sensing/camera/{}/camera_info", sensor_name),
+                    &format!("sensing/camera/{sensor_name}/camera_info"),
                 );
                 self.list_image_raw.insert(sensor_name.clone(), raw_key);
                 self.list_camera_info.insert(sensor_name, info_key);
@@ -98,7 +98,7 @@ impl Autoware {
                 let imu_key = topic_fmt(
                     &self.prefix,
                     &self.mode,
-                    &format!("sensing/imu/{}/imu_raw", sensor_name),
+                    &format!("sensing/imu/{sensor_name}/imu_raw"),
                 );
                 self.list_imu.insert(sensor_name.clone(), imu_key);
             }
@@ -115,7 +115,7 @@ impl Autoware {
                 let gnss_key = topic_fmt(
                     &self.prefix,
                     &self.mode,
-                    &format!("sensing/gnss/{}/nav_sat_fix", sensor_name),
+                    &format!("sensing/gnss/{sensor_name}/nav_sat_fix"),
                 );
                 self.list_gnss.insert(sensor_name.clone(), gnss_key);
             }

--- a/src/autoware.rs
+++ b/src/autoware.rs
@@ -1,10 +1,11 @@
 use std::collections::HashMap;
 
 use crate::bridge::sensor_bridge::SensorType;
+use crate::Mode;
 
-#[derive(Default, Clone)]
+#[derive(Clone)]
 pub struct Autoware {
-    pub _ros2: bool,
+    pub mode: Mode,
     pub prefix: String,
     pub _vehicle_name: String,
     // Vehicle publish topic
@@ -31,30 +32,36 @@ pub struct Autoware {
 }
 
 impl Autoware {
-    pub fn new(vehicle_name: String, ros2: bool) -> Autoware {
-        let prefix = if ros2 {
-            format!("{vehicle_name}/")
-        } else {
-            format!("{vehicle_name}/rt/")
+    pub fn new(vehicle_name: String, mode: Mode) -> Autoware {
+        let prefix = match mode {
+            Mode::ROS2 | Mode::RmwZenoh => format!("{}/", vehicle_name),
+            Mode::DDS => format!("{}/rt/", vehicle_name),
+        };
+        let topic = |base: &str| {
+            if mode == Mode::RmwZenoh {
+                format!("{prefix}*/{base}/*/*")
+            } else {
+                format!("{prefix}{base}")
+            }
         };
         Autoware {
-            _ros2: ros2,
+            mode: mode.clone(),
             prefix: prefix.clone(),
             _vehicle_name: vehicle_name,
             // Vehicle publish topic
-            topic_actuation_status: prefix.clone() + "vehicle/status/actuation_status",
-            topic_velocity_status: prefix.clone() + "vehicle/status/velocity_status",
-            topic_steering_status: prefix.clone() + "vehicle/status/steering_status",
-            topic_gear_status: prefix.clone() + "vehicle/status/gear_status",
-            topic_control_mode: prefix.clone() + "vehicle/status/control_mode",
-            topic_turn_indicators_status: prefix.clone() + "vehicle/status/turn_indicators_status",
-            topic_hazard_lights_status: prefix.clone() + "vehicle/status/hazard_lights_status",
+            topic_actuation_status:          topic("vehicle/status/actuation_status"),
+            topic_velocity_status:           topic("vehicle/status/velocity_status"),
+            topic_steering_status:           topic("vehicle/status/steering_status"),
+            topic_gear_status:               topic("vehicle/status/gear_status"),
+            topic_control_mode:              topic("vehicle/status/control_mode"),
+            topic_turn_indicators_status:    topic("vehicle/status/turn_indicators_status"),
+            topic_hazard_lights_status:      topic("vehicle/status/hazard_lights_status"),
             // Vehicle subscribe topic
-            topic_actuation_cmd: prefix.clone() + "control/command/actuation_cmd",
-            topic_gear_cmd: prefix.clone() + "control/command/gear_cmd",
-            topic_current_gate_mode: prefix.clone() + "control/current_gate_mode",
-            topic_turn_indicators_cmd: prefix.clone() + "control/command/turn_indicators_cmd",
-            topic_hazard_lights_cmd: prefix.clone() + "control/command/hazard_lights_cmd",
+            topic_actuation_cmd:             topic("control/command/actuation_cmd"),
+            topic_gear_cmd:                  topic("control/command/gear_cmd"),
+            topic_current_gate_mode:         topic("control/current_gate_mode"),
+            topic_turn_indicators_cmd:       topic("control/command/turn_indicators_cmd"),
+            topic_hazard_lights_cmd:         topic("control/command/hazard_lights_cmd"),
             // Sensor publish topic
             list_image_raw: HashMap::new(),
             list_camera_info: HashMap::new(),
@@ -68,36 +75,51 @@ impl Autoware {
     pub fn add_sensors(&mut self, sensor_type: SensorType, sensor_name: String) {
         match sensor_type {
             SensorType::CameraRgb => {
-                let raw_key = format!(
-                    "{}sensing/camera/{sensor_name}/image_raw",
-                    self.prefix.clone()
-                );
-                let info_key = format!(
-                    "{}sensing/camera/{sensor_name}/camera_info",
-                    self.prefix.clone()
-                );
+                let raw_key = if self.mode == Mode::RmwZenoh {
+                    format!("{}*/sensing/camera/{}/image_raw/*/*", self.prefix, sensor_name)
+                } else {
+                    format!("{}sensing/camera/{}/image_raw", self.prefix, sensor_name)
+                };
+                let info_key = if self.mode == Mode::RmwZenoh {
+                    format!("{}*/sensing/camera/{}/camera_info/*/*", self.prefix, sensor_name)
+                } else {
+                    format!("{}sensing/camera/{}/camera_info", self.prefix, sensor_name)
+                };
                 self.list_image_raw.insert(sensor_name.clone(), raw_key);
                 self.list_camera_info.insert(sensor_name, info_key);
             }
             SensorType::Collision => {}
             SensorType::Imu => {
-                let imu_key = format!("{}sensing/imu/{sensor_name}/imu_raw", self.prefix.clone());
+                let imu_key = if self.mode == Mode::RmwZenoh {
+                    format!("{}*/sensing/imu/{}/imu_raw/*/*", self.prefix, sensor_name)
+                } else {
+                    format!("{}sensing/imu/{}/imu_raw", self.prefix, sensor_name)
+                };
                 self.list_imu.insert(sensor_name.clone(), imu_key);
             }
             SensorType::LidarRayCast => {
-                let lidar_key = format!("{}carla_pointcloud", self.prefix.clone());
+                let lidar_key = if self.mode == Mode::RmwZenoh {
+                    format!("{}*/carla_pointcloud/*/*", self.prefix)
+                } else {
+                    format!("{}carla_pointcloud", self.prefix)
+                };
                 self.list_lidar.insert(sensor_name.clone(), lidar_key);
             }
             SensorType::LidarRayCastSemantic => {
-                let lidar_key = format!("{}carla_pointcloud", self.prefix.clone());
+                let lidar_key = if self.mode == Mode::RmwZenoh {
+                    format!("{}*/carla_pointcloud/*/*", self.prefix)
+                } else {
+                    format!("{}carla_pointcloud", self.prefix)
+                };
                 self.list_lidar_semantics
                     .insert(sensor_name.clone(), lidar_key);
             }
             SensorType::Gnss => {
-                let gnss_key = format!(
-                    "{}sensing/gnss/{sensor_name}/nav_sat_fix",
-                    self.prefix.clone()
-                );
+                let gnss_key = if self.mode == Mode::RmwZenoh {
+                    format!("{}*/sensing/gnss/{}/nav_sat_fix/*/*", self.prefix, sensor_name)
+                } else {
+                    format!("{}sensing/gnss/{}/nav_sat_fix", self.prefix, sensor_name)
+                };
                 self.list_gnss.insert(sensor_name.clone(), gnss_key);
             }
             SensorType::NotSupport => {}

--- a/src/autoware.rs
+++ b/src/autoware.rs
@@ -49,19 +49,19 @@ impl Autoware {
             prefix: prefix.clone(),
             _vehicle_name: vehicle_name,
             // Vehicle publish topic
-            topic_actuation_status:          topic("vehicle/status/actuation_status"),
-            topic_velocity_status:           topic("vehicle/status/velocity_status"),
-            topic_steering_status:           topic("vehicle/status/steering_status"),
-            topic_gear_status:               topic("vehicle/status/gear_status"),
-            topic_control_mode:              topic("vehicle/status/control_mode"),
-            topic_turn_indicators_status:    topic("vehicle/status/turn_indicators_status"),
-            topic_hazard_lights_status:      topic("vehicle/status/hazard_lights_status"),
+            topic_actuation_status: topic("vehicle/status/actuation_status"),
+            topic_velocity_status: topic("vehicle/status/velocity_status"),
+            topic_steering_status: topic("vehicle/status/steering_status"),
+            topic_gear_status: topic("vehicle/status/gear_status"),
+            topic_control_mode: topic("vehicle/status/control_mode"),
+            topic_turn_indicators_status: topic("vehicle/status/turn_indicators_status"),
+            topic_hazard_lights_status: topic("vehicle/status/hazard_lights_status"),
             // Vehicle subscribe topic
-            topic_actuation_cmd:             topic("control/command/actuation_cmd"),
-            topic_gear_cmd:                  topic("control/command/gear_cmd"),
-            topic_current_gate_mode:         topic("control/current_gate_mode"),
-            topic_turn_indicators_cmd:       topic("control/command/turn_indicators_cmd"),
-            topic_hazard_lights_cmd:         topic("control/command/hazard_lights_cmd"),
+            topic_actuation_cmd: topic("control/command/actuation_cmd"),
+            topic_gear_cmd: topic("control/command/gear_cmd"),
+            topic_current_gate_mode: topic("control/current_gate_mode"),
+            topic_turn_indicators_cmd: topic("control/command/turn_indicators_cmd"),
+            topic_hazard_lights_cmd: topic("control/command/hazard_lights_cmd"),
             // Sensor publish topic
             list_image_raw: HashMap::new(),
             list_camera_info: HashMap::new(),
@@ -76,12 +76,18 @@ impl Autoware {
         match sensor_type {
             SensorType::CameraRgb => {
                 let raw_key = if self.mode == Mode::RmwZenoh {
-                    format!("{}*/sensing/camera/{}/image_raw/*/*", self.prefix, sensor_name)
+                    format!(
+                        "{}*/sensing/camera/{}/image_raw/*/*",
+                        self.prefix, sensor_name
+                    )
                 } else {
                     format!("{}sensing/camera/{}/image_raw", self.prefix, sensor_name)
                 };
                 let info_key = if self.mode == Mode::RmwZenoh {
-                    format!("{}*/sensing/camera/{}/camera_info/*/*", self.prefix, sensor_name)
+                    format!(
+                        "{}*/sensing/camera/{}/camera_info/*/*",
+                        self.prefix, sensor_name
+                    )
                 } else {
                     format!("{}sensing/camera/{}/camera_info", self.prefix, sensor_name)
                 };
@@ -116,7 +122,10 @@ impl Autoware {
             }
             SensorType::Gnss => {
                 let gnss_key = if self.mode == Mode::RmwZenoh {
-                    format!("{}*/sensing/gnss/{}/nav_sat_fix/*/*", self.prefix, sensor_name)
+                    format!(
+                        "{}*/sensing/gnss/{}/nav_sat_fix/*/*",
+                        self.prefix, sensor_name
+                    )
                 } else {
                     format!("{}sensing/gnss/{}/nav_sat_fix", self.prefix, sensor_name)
                 };

--- a/src/autoware.rs
+++ b/src/autoware.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 
-use crate::bridge::sensor_bridge::SensorType;
-use crate::Mode;
+use crate::{bridge::sensor_bridge::SensorType, Mode};
 
 #[derive(Clone)]
 pub struct Autoware {

--- a/src/bridge/sensor_bridge.rs
+++ b/src/bridge/sensor_bridge.rs
@@ -134,19 +134,54 @@ impl SensorBridge {
 
         match sensor_type {
             SensorType::CameraRgb => {
-                register_camera_rgb(z_session, &actor, key_list, tx.clone(), rx, attachment.clone())?;
+                register_camera_rgb(
+                    z_session,
+                    &actor,
+                    key_list,
+                    tx.clone(),
+                    rx,
+                    attachment.clone(),
+                )?;
             }
             SensorType::LidarRayCast => {
-                register_lidar_raycast(z_session, &actor, key_list, tx.clone(), rx, attachment.clone())?;
+                register_lidar_raycast(
+                    z_session,
+                    &actor,
+                    key_list,
+                    tx.clone(),
+                    rx,
+                    attachment.clone(),
+                )?;
             }
             SensorType::LidarRayCastSemantic => {
-                register_lidar_raycast_semantic(z_session, &actor, key_list, tx.clone(), rx, attachment.clone())?;
+                register_lidar_raycast_semantic(
+                    z_session,
+                    &actor,
+                    key_list,
+                    tx.clone(),
+                    rx,
+                    attachment.clone(),
+                )?;
             }
             SensorType::Imu => {
-                register_imu(z_session, &actor, key_list, tx.clone(), rx, attachment.clone())?;
+                register_imu(
+                    z_session,
+                    &actor,
+                    key_list,
+                    tx.clone(),
+                    rx,
+                    attachment.clone(),
+                )?;
             }
             SensorType::Gnss => {
-                register_gnss(z_session, &actor, key_list, tx.clone(), rx, attachment.clone())?;
+                register_gnss(
+                    z_session,
+                    &actor,
+                    key_list,
+                    tx.clone(),
+                    rx,
+                    attachment.clone(),
+                )?;
             }
             SensorType::Collision => {
                 log::warn!("Collision sensor is not supported yet");
@@ -189,12 +224,20 @@ fn register_camera_rgb(
     thread::spawn(move || loop {
         match rx.recv() {
             Ok((MessageType::SensorData, sensor_data)) => {
-                if let Err(e) = image_publisher.put(sensor_data).attachment(attachment.clone()).wait() {
+                if let Err(e) = image_publisher
+                    .put(sensor_data)
+                    .attachment(attachment.clone())
+                    .wait()
+                {
                     log::error!("Failed to publish to {}: {:?}", raw_key, e);
                 }
             }
             Ok((MessageType::InfoData, info_data)) => {
-                if let Err(e) = info_publisher.put(info_data).attachment(attachment.clone()).wait() {
+                if let Err(e) = info_publisher
+                    .put(info_data)
+                    .attachment(attachment.clone())
+                    .wait()
+                {
                     log::error!("Failed to publish to {}: {:?}", info_key, e);
                 }
             }
@@ -265,7 +308,11 @@ fn register_lidar_raycast(
     thread::spawn(move || loop {
         match rx.recv() {
             Ok((MessageType::SensorData, sensor_data)) => {
-                if let Err(e) = pcd_publisher.put(sensor_data).attachment(attachment.clone()).wait() {
+                if let Err(e) = pcd_publisher
+                    .put(sensor_data)
+                    .attachment(attachment.clone())
+                    .wait()
+                {
                     log::error!("Failed to publish to {}: {:?}", key, e);
                 }
             }
@@ -305,7 +352,11 @@ fn register_lidar_raycast_semantic(
     thread::spawn(move || loop {
         match rx.recv() {
             Ok((MessageType::SensorData, sensor_data)) => {
-                if let Err(e) = pcd_publisher.put(sensor_data).attachment(attachment.clone()).wait() {
+                if let Err(e) = pcd_publisher
+                    .put(sensor_data)
+                    .attachment(attachment.clone())
+                    .wait()
+                {
                     log::error!("Failed to publish to {}: {:?}", key, e);
                 }
             }
@@ -345,7 +396,11 @@ fn register_imu(
     thread::spawn(move || loop {
         match rx.recv() {
             Ok((MessageType::SensorData, sensor_data)) => {
-                if let Err(e) = imu_publisher.put(sensor_data).attachment(attachment.clone()).wait() {
+                if let Err(e) = imu_publisher
+                    .put(sensor_data)
+                    .attachment(attachment.clone())
+                    .wait()
+                {
                     log::error!("Failed to publish to {}: {:?}", key, e);
                 }
             }
@@ -384,7 +439,11 @@ fn register_gnss(
     thread::spawn(move || loop {
         match rx.recv() {
             Ok((MessageType::SensorData, sensor_data)) => {
-                if let Err(e) = gnss_publisher.put(sensor_data).attachment(attachment.clone()).wait() {
+                if let Err(e) = gnss_publisher
+                    .put(sensor_data)
+                    .attachment(attachment.clone())
+                    .wait()
+                {
                     log::error!("Failed to publish to {}: {:?}", key, e);
                 }
             }

--- a/src/bridge/vehicle_bridge.rs
+++ b/src/bridge/vehicle_bridge.rs
@@ -250,11 +250,10 @@ impl<'a> VehicleBridge<'a> {
                 velocity.norm()
             },
             lateral_velocity: 0.0,
-            heading_rate: self
+            heading_rate: -self
                 .actor
                 .wheel_steer_angle(VehicleWheelLocation::FL_Wheel)
-                .to_radians()
-                * -1.0,
+                .to_radians(),
         };
         log::debug!(
             "Carla => Autoware: current velocity: {}",
@@ -274,11 +273,10 @@ impl<'a> VehicleBridge<'a> {
                 sec: timestamp.floor() as i32,
                 nanosec: (timestamp.fract() * 1_000_000_000_f64) as u32,
             },
-            steering_tire_angle: self
+            steering_tire_angle: -self
                 .actor
                 .wheel_steer_angle(VehicleWheelLocation::FL_Wheel)
-                .to_radians()
-                * -1.0,
+                .to_radians(),
         };
         let encoded = cdr::serialize::<_, _, CdrLe>(&steer_msg, Infinite)?;
         put_with_attachment!(self.publisher_steer, encoded, self.attachment, self.mode)?;

--- a/src/bridge/vehicle_bridge.rs
+++ b/src/bridge/vehicle_bridge.rs
@@ -1,5 +1,7 @@
-use std::sync::{atomic::Ordering, Arc};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::{
+    sync::{atomic::Ordering, Arc},
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 use arc_swap::ArcSwap;
 use atomic_float::AtomicF32;

--- a/src/bridge/vehicle_bridge.rs
+++ b/src/bridge/vehicle_bridge.rs
@@ -230,7 +230,10 @@ impl<'a> VehicleBridge<'a> {
             -control.steer
         );
         let encoded = cdr::serialize::<_, _, CdrLe>(&actuation_msg, Infinite)?;
-        self.publisher_actuation.put(encoded).attachment(self.attachment.clone()).wait()?;
+        self.publisher_actuation
+            .put(encoded)
+            .attachment(self.attachment.clone())
+            .wait()?;
         Ok(())
     }
 
@@ -261,7 +264,10 @@ impl<'a> VehicleBridge<'a> {
             velocity_msg.longitudinal_velocity
         );
         let encoded = cdr::serialize::<_, _, CdrLe>(&velocity_msg, Infinite)?;
-        self.publisher_velocity.put(encoded).attachment(self.attachment.clone()).wait()?;
+        self.publisher_velocity
+            .put(encoded)
+            .attachment(self.attachment.clone())
+            .wait()?;
         self.velocity
             .store(velocity_msg.longitudinal_velocity, Ordering::Relaxed);
 
@@ -281,7 +287,10 @@ impl<'a> VehicleBridge<'a> {
                 * -1.0,
         };
         let encoded = cdr::serialize::<_, _, CdrLe>(&steer_msg, Infinite)?;
-        self.publisher_steer.put(encoded).attachment(self.attachment.clone()).wait()?;
+        self.publisher_steer
+            .put(encoded)
+            .attachment(self.attachment.clone())
+            .wait()?;
         Ok(())
     }
 
@@ -294,7 +303,10 @@ impl<'a> VehicleBridge<'a> {
             report: **self.current_gear.load(),
         };
         let encoded = cdr::serialize::<_, _, CdrLe>(&gear_msg, Infinite)?;
-        self.publisher_gear.put(encoded).attachment(self.attachment.clone()).wait()?;
+        self.publisher_gear
+            .put(encoded)
+            .attachment(self.attachment.clone())
+            .wait()?;
         Ok(())
     }
 
@@ -312,7 +324,10 @@ impl<'a> VehicleBridge<'a> {
             mode,
         };
         let encoded = cdr::serialize::<_, _, CdrLe>(&control_msg, Infinite)?;
-        self.publisher_control.put(encoded).attachment(self.attachment.clone()).wait()?;
+        self.publisher_control
+            .put(encoded)
+            .attachment(self.attachment.clone())
+            .wait()?;
         Ok(())
     }
 
@@ -326,7 +341,10 @@ impl<'a> VehicleBridge<'a> {
             report: turn_indicators_report::DISABLE,
         };
         let encoded = cdr::serialize::<_, _, CdrLe>(&turnindicator_msg, Infinite)?;
-        self.publisher_turnindicator.put(encoded).attachment(self.attachment.clone()).wait()?;
+        self.publisher_turnindicator
+            .put(encoded)
+            .attachment(self.attachment.clone())
+            .wait()?;
         Ok(())
     }
 
@@ -340,7 +358,10 @@ impl<'a> VehicleBridge<'a> {
             report: hazard_lights_report::DISABLE,
         };
         let encoded = cdr::serialize::<_, _, CdrLe>(&hazardlight_msg, Infinite)?;
-        self.publisher_hazardlight.put(encoded).attachment(self.attachment.clone()).wait()?;
+        self.publisher_hazardlight
+            .put(encoded)
+            .attachment(self.attachment.clone())
+            .wait()?;
         Ok(())
     }
 

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -7,8 +7,7 @@ use cdr::{CdrLe, Infinite};
 use zenoh::{pubsub::Publisher, Session, Wait};
 use zenoh_ros_type::{builtin_interfaces, rosgraph_msgs};
 
-use crate::error::Result;
-use crate::Mode;
+use crate::{error::Result, Mode};
 
 pub struct SimulatorClock<'a> {
     publisher_clock: Publisher<'a>,

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -8,16 +8,32 @@ use zenoh::{pubsub::Publisher, Session, Wait};
 use zenoh_ros_type::{builtin_interfaces, rosgraph_msgs};
 
 use crate::error::Result;
+use crate::Mode;
 
 pub struct SimulatorClock<'a> {
     publisher_clock: Publisher<'a>,
+    attachment: Vec<u8>,
 }
 
 impl<'a> SimulatorClock<'a> {
-    pub fn new(z_session: Arc<Session>, ros2: bool) -> Result<SimulatorClock<'a>> {
-        let key = if ros2 { "*/clock" } else { "*/rt/clock" };
+    pub fn new(z_session: Arc<Session>, mode: Mode) -> Result<SimulatorClock<'a>> {
+        let key = match mode {
+            Mode::RmwZenoh => "*/*/clock/*/*".to_string(),
+            Mode::ROS2 => "*/clock".to_string(),
+            Mode::DDS => "*/rt/clock".to_string(),
+        };
         let publisher_clock = z_session.declare_publisher(key).wait()?;
-        Ok(SimulatorClock { publisher_clock })
+        
+        // Initialize attachment
+        let seq_num: i64 = 1;
+        let mut attachment = seq_num.to_le_bytes().to_vec();
+        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
+        let timestamp: i64 = now.as_nanos() as i64;
+        attachment.extend_from_slice(&timestamp.to_le_bytes());
+        attachment.push(16u8);
+        attachment.extend_from_slice(&[0xAB; 16]);
+        
+        Ok(SimulatorClock { publisher_clock, attachment })
     }
 
     pub fn publish_clock(&self, timestamp: Option<f64>) -> Result<()> {
@@ -38,7 +54,7 @@ impl<'a> SimulatorClock<'a> {
         };
         let clock_msg = rosgraph_msgs::Clock { clock: time };
         let encoded = cdr::serialize::<_, _, CdrLe>(&clock_msg, Infinite)?;
-        self.publisher_clock.put(encoded).wait()?;
+        self.publisher_clock.put(encoded).attachment(self.attachment.clone()).wait()?;
         Ok(())
     }
 }

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -23,7 +23,7 @@ impl<'a> SimulatorClock<'a> {
             Mode::DDS => "*/rt/clock".to_string(),
         };
         let publisher_clock = z_session.declare_publisher(key).wait()?;
-        
+
         // Initialize attachment
         let seq_num: i64 = 1;
         let mut attachment = seq_num.to_le_bytes().to_vec();
@@ -32,8 +32,11 @@ impl<'a> SimulatorClock<'a> {
         attachment.extend_from_slice(&timestamp.to_le_bytes());
         attachment.push(16u8);
         attachment.extend_from_slice(&[0xAB; 16]);
-        
-        Ok(SimulatorClock { publisher_clock, attachment })
+
+        Ok(SimulatorClock {
+            publisher_clock,
+            attachment,
+        })
     }
 
     pub fn publish_clock(&self, timestamp: Option<f64>) -> Result<()> {
@@ -54,7 +57,10 @@ impl<'a> SimulatorClock<'a> {
         };
         let clock_msg = rosgraph_msgs::Clock { clock: time };
         let encoded = cdr::serialize::<_, _, CdrLe>(&clock_msg, Infinite)?;
-        self.publisher_clock.put(encoded).attachment(self.attachment.clone()).wait()?;
+        self.publisher_clock
+            .put(encoded)
+            .attachment(self.attachment.clone())
+            .wait()?;
         Ok(())
     }
 }

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -12,10 +12,13 @@ use crate::{error::Result, Mode};
 pub struct SimulatorClock<'a> {
     publisher_clock: Publisher<'a>,
     attachment: Vec<u8>,
+    mode: Mode,
 }
 
 impl<'a> SimulatorClock<'a> {
     pub fn new(z_session: Arc<Session>, mode: Mode) -> Result<SimulatorClock<'a>> {
+        // If the mode is RmwZenoh, it will use the Zenoh key expression format; otherwise, it will use the standard ROS 2 format.
+        // See: https://github.com/ros2/rmw_zenoh/blob/rolling/docs/design.md#topic-and-service-name-mapping-to-zenoh-key-expressions
         let key = match mode {
             Mode::RmwZenoh => "*/*/clock/*/*".to_string(),
             Mode::ROS2 => "*/clock".to_string(),
@@ -23,18 +26,18 @@ impl<'a> SimulatorClock<'a> {
         };
         let publisher_clock = z_session.declare_publisher(key).wait()?;
 
-        // Initialize attachment
+        // The attachment format is required for interoperability with rmw_zenoh; see:
+        // https://github.com/ros2/rmw_zenoh/blob/rolling/docs/design.md#publishers
         let seq_num: i64 = 1;
         let mut attachment = seq_num.to_le_bytes().to_vec();
-        let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
-        let timestamp: i64 = now.as_nanos() as i64;
-        attachment.extend_from_slice(&timestamp.to_le_bytes());
+        attachment.extend_from_slice(&0i64.to_le_bytes());
         attachment.push(16u8);
         attachment.extend_from_slice(&[0xAB; 16]);
 
         Ok(SimulatorClock {
             publisher_clock,
             attachment,
+            mode,
         })
     }
 
@@ -56,10 +59,16 @@ impl<'a> SimulatorClock<'a> {
         };
         let clock_msg = rosgraph_msgs::Clock { clock: time };
         let encoded = cdr::serialize::<_, _, CdrLe>(&clock_msg, Infinite)?;
-        self.publisher_clock
-            .put(encoded)
-            .attachment(self.attachment.clone())
-            .wait()?;
+
+        // If the mode is RmwZenoh, it will add the attachment; otherwise, it will not.
+        if self.mode == Mode::RmwZenoh {
+            self.publisher_clock
+                .put(encoded)
+                .attachment(self.attachment.clone())
+                .wait()?;
+        } else {
+            self.publisher_clock.put(encoded).wait()?;
+        }
         Ok(())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,9 +146,9 @@ fn main() -> Result<()> {
                 let actor = actor_list.remove(&id).expect("ID should be in the list!");
                 let bridge = match bridge::actor_bridge::get_bridge_type(actor.clone()) {
                     Ok(BridgeType::Vehicle(vehicle_name)) => {
-                        let aw = autoware_list.entry(vehicle_name.clone()).or_insert(
-                            autoware::Autoware::new(vehicle_name.clone(), mode.clone()),
-                        );
+                        let aw = autoware_list
+                            .entry(vehicle_name.clone())
+                            .or_insert(autoware::Autoware::new(vehicle_name.clone(), mode.clone()));
                         bridge::actor_bridge::create_bridge(
                             z_session.clone(),
                             actor,
@@ -157,9 +157,9 @@ fn main() -> Result<()> {
                         )?
                     }
                     Ok(BridgeType::Sensor(vehicle_name, sensor_type, sensor_name)) => {
-                        let aw = autoware_list.entry(vehicle_name.clone()).or_insert(
-                            autoware::Autoware::new(vehicle_name.clone(), mode.clone()),
-                        );
+                        let aw = autoware_list
+                            .entry(vehicle_name.clone())
+                            .or_insert(autoware::Autoware::new(vehicle_name.clone(), mode.clone()));
                         aw.add_sensors(sensor_type, sensor_name.clone());
                         bridge::actor_bridge::create_bridge(
                             z_session.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,8 @@ enum Mode {
     DDS,
     /// Using zenoh-bridge-ros2dds
     ROS2,
+    /// Using rmw_zenoh
+    RmwZenoh,
 }
 
 /// Zenoh Carla bridge for Autoware
@@ -111,7 +113,7 @@ fn main() -> Result<()> {
     let mut bridge_list: HashMap<ActorId, Box<dyn ActorBridge>> = HashMap::new();
 
     // Create clock publisher
-    let simulator_clock = SimulatorClock::new(z_session.clone(), mode == Mode::ROS2)
+    let simulator_clock = SimulatorClock::new(z_session.clone(), mode.clone())
         .expect("Unable to create simulator clock!");
 
     // Create thread for ticking
@@ -145,7 +147,7 @@ fn main() -> Result<()> {
                 let bridge = match bridge::actor_bridge::get_bridge_type(actor.clone()) {
                     Ok(BridgeType::Vehicle(vehicle_name)) => {
                         let aw = autoware_list.entry(vehicle_name.clone()).or_insert(
-                            autoware::Autoware::new(vehicle_name.clone(), mode == Mode::ROS2),
+                            autoware::Autoware::new(vehicle_name.clone(), mode.clone()),
                         );
                         bridge::actor_bridge::create_bridge(
                             z_session.clone(),
@@ -156,7 +158,7 @@ fn main() -> Result<()> {
                     }
                     Ok(BridgeType::Sensor(vehicle_name, sensor_type, sensor_name)) => {
                         let aw = autoware_list.entry(vehicle_name.clone()).or_insert(
-                            autoware::Autoware::new(vehicle_name.clone(), mode == Mode::ROS2),
+                            autoware::Autoware::new(vehicle_name.clone(), mode.clone()),
                         );
                         aw.add_sensors(sensor_type, sensor_name.clone());
                         bridge::actor_bridge::create_bridge(

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -44,7 +44,7 @@ pub fn generate_attachment() -> Vec<u8> {
 #[macro_export]
 macro_rules! put_with_attachment {
     ($publisher:expr, $payload:expr, $attachment:expr, $mode:expr) => {
-        if $mode == crate::Mode::RmwZenoh {
+        if $mode == $crate::Mode::RmwZenoh {
             $publisher
                 .put($payload)
                 .attachment($attachment.clone())


### PR DESCRIPTION
Added a new mode called rmw_zenoh mode. The topic names will be different depends on the mode. 
Also added an attachment. I just included the attachment no matter what mode it is. I tested it with both rmw_zenoh mode and bridge mode and it didn’t seem to have any issues.