### PR TITLE
feat(carla_agent): support multiple ego vehicles

### DIFF
--- a/carla_agent/main.py
+++ b/carla_agent/main.py
@@ -65,6 +65,7 @@ def main():
     argparser.add_argument('--rolename', metavar='NAME', default='v1', help='actor role name (default: "v1")')
     argparser.add_argument('--gamma', default=2.2, type=float, help='Gamma correction of the camera (default: 2.2)')
     argparser.add_argument('--sync', action='store_true', help='Activate synchronous mode execution')
+    argparser.add_argument('--attach', action='store_true', help='Attach to the existing world (get_world) instead of loading a new one')
     argparser.add_argument('--pygame', action='store_true', help='Run with pygame')
     argparser.add_argument(
         '--position',

--- a/carla_agent/set_world.py
+++ b/carla_agent/set_world.py
@@ -1,0 +1,13 @@
+"""Load the configured world once so per-vehicle agents can `main.py --attach`
+to it without each reloading (a reload destroys every other vehicle's actors)."""
+import sys
+
+import carla
+
+from simulation import config
+
+host = sys.argv[1] if len(sys.argv) > 1 else '127.0.0.1'
+client = carla.Client(host, 2000)
+client.set_timeout(60.0)
+client.load_world(config.SIM_WORLD)
+print('world loaded:', config.SIM_WORLD)

--- a/carla_agent/simple_spawn.py
+++ b/carla_agent/simple_spawn.py
@@ -22,6 +22,8 @@ def main():
 
     sim_world = client.load_world(config.SIM_WORLD)
 
+    sensors = []  # collect and keep all the sensors alive
+
     for vehicle_name, position in vehicle_list:
         # vehicles settings
         vehicles = sim_world.get_blueprint_library().filter('vehicle.tesla.model3')
@@ -49,10 +51,10 @@ def main():
         vehicle_actor.apply_physics_control(physics_control)
 
         # Setup sensors
-        _gnss_sensor = GnssSensor(vehicle_actor, sensor_name='ublox')
-        _imu_sensor = IMUSensor(vehicle_actor, sensor_name='tamagawa')
-        _lidar_sensor = LidarSensor(vehicle_actor, sensor_name='top')
-        _rgb_camera = RgbCamera(vehicle_actor, sensor_name='traffic_light')
+        sensors.append((GnssSensor(vehicle_actor, sensor_name='ublox'),
+                        IMUSensor(vehicle_actor, sensor_name='tamagawa'),
+                        LidarSensor(vehicle_actor, sensor_name='top'),
+                        RgbCamera(vehicle_actor, sensor_name='traffic_light')))
 
     while True:
         sim_world.wait_for_tick()

--- a/carla_agent/simulation/loop.py
+++ b/carla_agent/simulation/loop.py
@@ -20,8 +20,12 @@ def game_loop(args, doc):
         client = carla.Client(args.host, args.port)
         client.set_timeout(20.0)
 
-        sim_world = client.load_world(config.SIM_WORLD)
-        # sim_world = client.get_world()
+        # --attach lets several agents share one world: only the first run loads
+        # it, the rest get_world() so they don't reload (which destroys actors).
+        if args.attach:
+            sim_world = client.get_world()
+        else:
+            sim_world = client.load_world(config.SIM_WORLD)
         if args.sync:
             original_settings = sim_world.get_settings()
             settings = sim_world.get_settings()


### PR DESCRIPTION
## Summary

Running one agent per vehicle didn't work because each `main.py` calls `load_world()` on startup, and `load_world` destroys every actor in the world — so the second agent wipes the first vehicle. This PR lets agents share one world.

## Changes

- **`--attach` (`main.py` / `simulation/loop.py`)**: with this flag the agent calls `get_world()` instead of `load_world()`, so it joins the world that is already loaded instead of reloading (and wiping) it.
- **`set_world.py`**: a one-shot helper that loads the configured world once, up front, so the `--attach` agents have a world to join.
- **`simple_spawn.py`**: keep the spawned sensors in a list so earlier vehicles' sensors aren't garbage-collected and destroyed (their `__del__` calls `destroy()`).

## Usage

```bash
python set_world.py                      # load the world once
python main.py --attach --rolename v1    # one agent per vehicle
python main.py --attach --rolename v2
```

`--attach` defaults off, so existing single-vehicle usage (`main.py`, `run-bridge.sh`) is unchanged.