### PR TITLE
feat(carla_agent): support multiple ego vehicles

### DIFF
--- a/carla_agent/main.py
+++ b/carla_agent/main.py
@@ -65,6 +65,7 @@ def main():
     argparser.add_argument('--rolename', metavar='NAME', default='v1', help='actor role name (default: "v1")')
     argparser.add_argument('--gamma', default=2.2, type=float, help='Gamma correction of the camera (default: 2.2)')
     argparser.add_argument('--sync', action='store_true', help='Activate synchronous mode execution')
+    argparser.add_argument('--attach', action='store_true', help='Attach to the existing world (get_world) instead of loading a new one')
     argparser.add_argument('--pygame', action='store_true', help='Run with pygame')
     argparser.add_argument(
         '--position',

--- a/carla_agent/set_world.py
+++ b/carla_agent/set_world.py
@@ -1,0 +1,13 @@
+"""Load the configured world once so per-vehicle agents can `main.py --attach`
+to it without each reloading (a reload destroys every other vehicle's actors)."""
+import sys
+
+import carla
+
+from simulation import config
+
+host = sys.argv[1] if len(sys.argv) > 1 else '127.0.0.1'
+client = carla.Client(host, 2000)
+client.set_timeout(60.0)
+client.load_world(config.SIM_WORLD)
+print('world loaded:', config.SIM_WORLD)

--- a/carla_agent/simple_spawn.py
+++ b/carla_agent/simple_spawn.py
@@ -22,6 +22,8 @@ def main():
 
     sim_world = client.load_world(config.SIM_WORLD)
 
+    sensors = []  # collect and keep all the sensors alive
+
     for vehicle_name, position in vehicle_list:
         # vehicles settings
         vehicles = sim_world.get_blueprint_library().filter('vehicle.tesla.model3')
@@ -49,10 +51,10 @@ def main():
         vehicle_actor.apply_physics_control(physics_control)
 
         # Setup sensors
-        _gnss_sensor = GnssSensor(vehicle_actor, sensor_name='ublox')
-        _imu_sensor = IMUSensor(vehicle_actor, sensor_name='tamagawa')
-        _lidar_sensor = LidarSensor(vehicle_actor, sensor_name='top')
-        _rgb_camera = RgbCamera(vehicle_actor, sensor_name='traffic_light')
+        sensors.append((GnssSensor(vehicle_actor, sensor_name='ublox'),
+                        IMUSensor(vehicle_actor, sensor_name='tamagawa'),
+                        LidarSensor(vehicle_actor, sensor_name='top'),
+                        RgbCamera(vehicle_actor, sensor_name='traffic_light')))
 
     while True:
         sim_world.wait_for_tick()

--- a/carla_agent/simulation/loop.py
+++ b/carla_agent/simulation/loop.py
@@ -20,8 +20,12 @@ def game_loop(args, doc):
         client = carla.Client(args.host, args.port)
         client.set_timeout(20.0)
 
-        sim_world = client.load_world(config.SIM_WORLD)
-        # sim_world = client.get_world()
+        # --attach lets several agents share one world: only the first run loads
+        # it, the rest get_world() so they don't reload (which destroys actors).
+        if args.attach:
+            sim_world = client.get_world()
+        else:
+            sim_world = client.load_world(config.SIM_WORLD)
         if args.sync:
             original_settings = sim_world.get_settings()
             settings = sim_world.get_settings()


### PR DESCRIPTION
## Summary

Port from then main branch.

Running one agent per vehicle didn't work, because each `main.py` calls `load_world()` on startup and `load_world` destroys every actor in the world — so the second agent wipes the first vehicle. On top of that, spawned sensors were dropped as the spawn loop overwrote its per-vehicle locals, and `LidarSensor` / `RgbCamera` `__del__` destroy the Carla actor, so every vehicle but the last lost its lidar and camera. This PR lets agents share one world and keeps their sensors alive.